### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ install:
 before_script:
   - $HOME/chromedriver --url-base=/wd/hub &
   - php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
-  - sleep 5 && curl --fail --head http://127.0.0.1:8080/index-test.php
+  - sleep 5
+  - curl --fail --head http://127.0.0.1:8080/index-test.php
 
 script:
   - cd tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language: php
+sudo: enabled
+
+services:
+  - mysql
+
+addons:
+  chrome: stable
+
+git:
+  depth: 3
+
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
+
+env:
+  global:
+    - HUMHUB_PATH=/opt/humhub
+  matrix:
+    - HUMHUB_VERSION=master
+    - HUMHUB_VERSION=v1.3-dev
+
+matrix:
+  allow_failures:
+    - env: HUMHUB_VERSION=v1.3-dev
+  exclude:
+    - php: '7.2'
+      env: HUMHUB_VERSION=master
+  fast_finish: true
+
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install:
+  - chmod +x .travis/*.sh
+
+install:
+  - .travis/install-dependencies.sh
+  - .travis/setup-humhub.sh
+
+before_script:
+  - $HOME/chromedriver --url-base=/wd/hub &
+  - php --server 127.0.0.1:8080 --docroot ${HUMHUB_PATH} &>/dev/null &
+  - sleep 5 && curl --fail --head http://127.0.0.1:8080/index-test.php
+
+script:
+  - cd tests
+  - php ${HUMHUB_PATH}/protected/vendor/bin/codecept build
+  - php ${HUMHUB_PATH}/protected/vendor/bin/codecept run

--- a/.travis/install-dependencies.sh
+++ b/.travis/install-dependencies.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# -e = exit when one command returns != 0, -v print each command before executing
+set -ev
+
+# Install chomedriver
+curl -s -L -o chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip \
+    && unzip -o -d $HOME chromedriver_linux64.zip \
+	&& chmod +x $HOME/chromedriver
+
+# Install composer package
+composer global require fxp/composer-asset-plugin

--- a/.travis/setup-humhub.sh
+++ b/.travis/setup-humhub.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+# -e = exit when one command returns != 0, -v print each command before executing
+set -ev
+
+old=$(pwd)
+
+mkdir ${HUMHUB_PATH}
+cd ${HUMHUB_PATH}
+
+git clone --branch ${HUMHUB_VERSION} --depth 1 https://github.com/humhub/humhub.git .
+composer install --prefer-dist --no-interaction
+
+cd ${HUMHUB_PATH}/protected/humhub/tests
+
+sed -i -e "s|'installed' => true,|'installed' => true,\n\t'moduleAutoloadPaths' => ['$(dirname $old)']|g" config/common.php
+#cat config/common.php
+
+mysql -e 'CREATE DATABASE humhub_test;'
+php codeception/bin/yii migrate/up --includeModuleMigrations=1 --interactive=0
+php codeception/bin/yii installer/auto
+php codeception/bin/yii search/rebuild
+
+php ${HUMHUB_PATH}/protected/vendor/bin/codecept build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/humhub/humhub-modules-tasks.svg?branch=master)](https://travis-ci.org/humhub/humhub-modules-tasks)
+
 Tasks Module
 ==============
 

--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -1,29 +1,35 @@
 <?php
 /**
+ * @link https://www.humhub.org/
+ * @copyright Copyright (c) 2015 HumHub GmbH & Co. KG
+ * @license https://www.humhub.com/licences
+ */
+
+/*
  * This is the initial test bootstrap, which will load the default test bootstrap from the humhub core
  */
 
 $testRoot = dirname(__DIR__);
+
 \Codeception\Configuration::append(['test_root' => $testRoot]);
+echo 'Module root: ' . $testRoot . PHP_EOL;
 
-$humhubPath = getenv("HUMHUB_PATH");
-
-// If no environment path was set, we assume residing in default the modules directory
-if($humhubPath == null) {
-    $testCfg = require_once($testRoot.'/config/test.php');
-    if(isset($testCfg['humhub_root'])) {
-        $humhubPath = $testCfg['humhub_root'];
+$humhubPath = getenv('HUMHUB_PATH');
+if ($humhubPath === false) {
+    // If no environment path was set, we assume residing in default the modules directory
+    $moduleConfig = require $testRoot . '/config/test.php';
+    if (isset($moduleConfig['humhub_root'])) {
+        $humhubPath = $moduleConfig['humhub_root'];
     } else {
-        $humhubPath = dirname(__DIR__).'../../../../';
+        $humhubPath = dirname(__DIR__, 5);
     }
 }
 
 \Codeception\Configuration::append(['humhub_root' => $humhubPath]);
+echo 'HumHub Root: ' . $humhubPath . PHP_EOL;
 
 // Load test configuration (/config/test.php or /config/env/<environment>/test.php
-$cfg = require($humhubPath . '/protected/humhub/tests/codeception/_loadConfig.php');
-
-print_r('Using HumHub Root: ' . $cfg['humhub_root']);
+$globalConfig = require $humhubPath . '/protected/humhub/tests/codeception/_loadConfig.php';
 
 // Load default test bootstrap (initialize Yii...)
-require_once($cfg['humhub_root'] . '/protected/humhub/tests/codeception/_bootstrap.php');
+require $globalConfig['humhub_root'] . '/protected/humhub/tests/codeception/_bootstrap.php';

--- a/tests/codeception/acceptance.suite.yml
+++ b/tests/codeception/acceptance.suite.yml
@@ -10,15 +10,14 @@
 
 class_name: AcceptanceTester
 modules:
-    enabled:
-        #- PhpBrowser
-        - WebDriver
-        - tests\codeception\_support\WebHelper
-        - tests\codeception\_support\DynamicFixtureHelper
-    config:
-        PhpBrowser:
-            url: http://localhost:8080/
-        WebDriver:
-            url: http://localhost:8080/
-            browser: firefox
-            restart: false
+  enabled:
+    - WebDriver:
+        url: 'http://localhost:8080/'
+        window_size: false # disabled in ChromeDriver
+        port: 9515
+        browser: chrome
+        capabilities:
+          chromeOptions:
+            args: ['--headless', '--disable-gpu', '--no-sandbox']
+    - tests\codeception\_support\WebHelper
+    - tests\codeception\_support\DynamicFixtureHelper


### PR DESCRIPTION
Enable Travis-CI for Polls-Module

- Build as matrix against PHP 5.6, 7.0, 7.1, 7.2 and Humhub master / v1.3-dev
- Allow failure for v1.3-dev
- Dont test master against PHP 7.2

Please enable Travis-CI for this repository before merge. Current build for my fork: https://travis-ci.org/danielkesselberg/humhub-modules-tasks